### PR TITLE
Add sigma_sum search utility

### DIFF
--- a/src/simulation/tests/test_find_sigma_sum.py
+++ b/src/simulation/tests/test_find_sigma_sum.py
@@ -1,0 +1,31 @@
+import numpy as np
+from simulation.mean_cv_autocorr_v2 import find_sigma_sum
+from stats.mean import calculate_mean_from_params
+from stats.cv import calculate_cv_from_params
+from stats.autocorrelation import calculate_ac_from_params
+
+
+def test_find_sigma_sum():
+    # Choose a representative target system
+    mu_target = 1.0
+    t_ac_target = 0.5
+    cv_target = 1.5
+
+    # Search for the smallest sigma_sum that reproduces the targets
+    sigma_sum, rho, d, sigma_b, sigma_u = find_sigma_sum(
+        mu_target, t_ac_target, cv_target, tolerance=1e-3
+    )
+
+    # Recompute the metrics from the returned parameters to verify that the
+    # helper indeed met the requested targets
+    mu_est = calculate_mean_from_params(rho, d, sigma_b, sigma_u)
+    cv_est = calculate_cv_from_params(rho, d, sigma_b, sigma_u)
+    ac_est = calculate_ac_from_params(rho, d, sigma_b, sigma_u, t_ac_target)
+
+    # Mean and CV are compared relative to the target to ensure high accuracy
+    assert abs((mu_est - mu_target) / mu_target) < 1e-6
+    assert abs((cv_est - cv_target) / cv_target) < 1e-6
+    # Autocorrelation target is absolute as exp(-1) is a concrete value
+    assert abs(ac_est - np.exp(-1)) < 1e-3
+    # sigma_sum should be a positive scaling factor
+    assert sigma_sum > 0

--- a/src/simulation/tests/test_find_tilda_simulation.py
+++ b/src/simulation/tests/test_find_tilda_simulation.py
@@ -1,0 +1,54 @@
+import numpy as np
+from simulation.mean_cv_autocorr_v2 import find_tilda_parameters
+from simulation.simulate_telegraph_model import simulate_one_telegraph_model_system
+from stats.mean import calculate_mean
+from stats.variance import calculate_variance
+from stats.cv import calculate_cv
+from stats.autocorrelation import calculate_autocorrelation, calculate_ac_time_interp1d
+
+
+def test_find_tilda_parameters_matches_simulation():
+    """Parameters returned by ``find_tilda_parameters`` should reproduce
+    the requested statistics when used in stochastic simulations.
+    The test uses a small system to keep execution time reasonable
+    while still verifying mean, CV and autocorrelation time."""
+
+    mu_target = 10.0
+    t_ac_target = 1.5
+    cv_target = 1.0
+
+    # Derive kinetic parameters; the seed speeds up convergence for this regime
+    rho, d, sigma_b, sigma_u = find_tilda_parameters(
+        mu_target, t_ac_target, cv_target, sigma_sum_seed=20.0
+    )
+
+    param_set = [
+        {
+            "sigma_b": sigma_b,
+            "sigma_u": sigma_u,
+            "rho": rho,
+            "d": d,
+            "label": 0,
+        }
+    ]
+
+    time_points = np.arange(0, 200, 1.0)
+    np.random.seed(0)
+    df_results = simulate_one_telegraph_model_system(
+        param_set, time_points, size=100, num_cores=1
+    )
+
+    trajectories = df_results[df_results["label"] == 0].drop("label", axis=1).values
+    mean_obs = calculate_mean(trajectories, param_set, use_steady_state=False)
+    var_obs = calculate_variance(trajectories, param_set, use_steady_state=False)
+    cv_obs = calculate_cv(var_obs, mean_obs)
+
+    ac_results = calculate_autocorrelation(df_results)
+    ac_mean = ac_results["stress_ac"].mean(axis=0)
+    lags = ac_results["stress_lags"]
+    ac_time_obs = calculate_ac_time_interp1d(ac_mean, lags)
+
+    # Allow small deviations due to stochasticity in the simulation
+    assert abs(mean_obs - mu_target) / mu_target < 0.2
+    assert abs(cv_obs - cv_target) / cv_target < 0.2
+    assert abs(ac_time_obs - t_ac_target) / t_ac_target < 0.2

--- a/src/simulation/tests/test_mean_cv_autocorr_v2.py
+++ b/src/simulation/tests/test_mean_cv_autocorr_v2.py
@@ -13,10 +13,8 @@ def test_find_tilda_parameters_analytical():
     mu_target = 10
     autocorr_target = 2
     cv_target = 0.5
-    sigma_sum = 5
-    
     # Get the parameters using the scaled equations
-    rho, d, sigma_b, sigma_u = find_tilda_parameters(sigma_sum, mu_target, autocorr_target, cv_target)
+    rho, d, sigma_b, sigma_u = find_tilda_parameters(mu_target, autocorr_target, cv_target)
     print('Parameters found:', rho, d, sigma_b, sigma_u)
     
     # Plug back in to verify
@@ -40,23 +38,25 @@ def test_find_tilda_parameters_simulation():
     mu_target = 10
     autocorr_target = 2
     cv_target = 0.5
-    sigma_sum = 5
-    
     # Get the parameters using the scaled equations
-    rho, d, sigma_b, sigma_u = find_tilda_parameters(sigma_sum, mu_target, autocorr_target, cv_target)
+    rho, d, sigma_b, sigma_u = find_tilda_parameters(mu_target, autocorr_target, cv_target)
     
     # Create parameter set for simulation
-    parameter_set = [{'sigmab': sigma_b,
-                      'sigma_u': sigma_u,
-                      'rho': rho,
-                      'd': d,
-                      'label': 0
-                      }]
-    
+    parameter_set = [
+        {
+            'sigma_b': sigma_b,
+            'sigma_u': sigma_u,
+            'rho': rho,
+            'd': d,
+            'label': 0
+        }
+    ]
+
     # Run simulation
     time_points = np.arange(0, 144.0, 1.0)
     size = 200
-    df_results = simulate_one_telegraph_model_system(parameter_set, time_points, size)
+    # Use a single core to avoid multiprocessing overhead during tests
+    df_results = simulate_one_telegraph_model_system(parameter_set, time_points, size, num_cores=1)
     
     # Extract trajectories (remove label column and convert to numpy array)
     trajectories = df_results[df_results['label'] == 0].drop('label', axis=1).values


### PR DESCRIPTION
## Summary
- extract core solver into private `_solve_tilda_parameters`
- integrate sigma_sum search into `find_tilda_parameters`
- fix telegraph simulation to read parameter dict by key and allow single-core runs
- add integration test checking stochastic simulations reproduce target mean, CV and autocorrelation

## Testing
- `PYTHONPATH=src pytest src/simulation/tests/test_mean_cv_autocorr_v2.py src/simulation/tests/test_find_sigma_sum.py src/simulation/tests/test_find_tilda_simulation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6898a82d898c8321901b204b483ed6e4