### PR TITLE
feat: unify labeling utilities

### DIFF
--- a/src/utils/tests/test_data_processing.py
+++ b/src/utils/tests/test_data_processing.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Ensure the src directory is on the Python path for module imports
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from utils.data_processing import add_labels
+
+
+def test_add_labels_nearest_neighbour_pairing():
+    df = pd.DataFrame(
+        {
+            "mu_target": [1.0, 1.1, 2.0, 2.05],
+            "cv_target": [0.1, 0.1, 0.2, 0.2],
+            "t_ac_target": [0.5, 0.5, 0.6, 0.6],
+        }
+    )
+    labelled = add_labels(df, labeling_regime="nearest_neighbour")
+    assert labelled["label"].tolist() == [0, 1, 0, 1]
+
+
+def test_add_labels_binary_split():
+    df = pd.DataFrame({"mu_target": [1.0, 2.0, 3.0, 4.0]})
+    labelled = add_labels(df, labeling_regime="binary", column="mu_target")
+    assert labelled["label"].tolist() == [0, 0, 1, 1]
+


### PR DESCRIPTION
## Summary
- provide `add_binary_labels` and `add_nearest_neighbour_labels` as primary helpers
- expose `add_labels` as a small wrapper selecting between the two implementations
- standardize nearest-neighbour default to `t_ac_target`

## Testing
- `pytest src/utils/tests/test_data_processing.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'simulation'; FileNotFoundError: missing experiment CSV; ModuleNotFoundError: No module named 'mywela'; ModuleNotFoundError: No module named 'stochpy'; ModuleNotFoundError: No module named 'wela')*

------
https://chatgpt.com/codex/tasks/task_e_68b19e733c208321b97418cb3eeb866f